### PR TITLE
Fix extraneous space in chat messages when using empty prefix.

### DIFF
--- a/UltimateChat-Spigot/src/main/java/br/net/fabiozumbi12/UltimateChat/Bukkit/config/UCLang.java
+++ b/UltimateChat-Spigot/src/main/java/br/net/fabiozumbi12/UltimateChat/Bukkit/config/UCLang.java
@@ -158,6 +158,14 @@ public class UCLang {
 
         return FMsg.replace("\\n", "\n");
     }
+    
+    private String getPrefix(final CommandSender sender) {
+        String prefix = get(sender, "_UChat.prefix");
+        if (ChatColor.stripColor(prefix).isEmpty()) {
+            return prefix;
+        }
+        return prefix + " ";
+    }
 
     public void sendMessage(final Player p, String key) {
         if (delayedMessage.containsKey(p) && delayedMessage.get(p).equals(key)) {
@@ -165,11 +173,11 @@ public class UCLang {
         }
 
         if (!loadedlang.containsKey(key)) {
-            p.sendMessage(get(p, "_UChat.prefix") + " " + UCMessages.formatTags("", UChatColor.translateAlternateColorCodes(key), p, "", "", UChat.get().getPlayerChannel(p)));
+            p.sendMessage(getPrefix(p) + UCMessages.formatTags("", UChatColor.translateAlternateColorCodes(key), p, "", "", UChat.get().getPlayerChannel(p)));
         } else if (get(key).isEmpty()) {
             return;
         } else {
-            p.sendMessage(get(p, "_UChat.prefix") + " " + get(p, key));
+            p.sendMessage(getPrefix(p) + get(p, key));
         }
 
         delayedMessage.put(p, key);
@@ -184,11 +192,11 @@ public class UCLang {
         }
 
         if (loadedlang.get(key) == null) {
-            sender.sendMessage(get(sender, "_UChat.prefix") + " " + UCMessages.formatTags("", UChatColor.translateAlternateColorCodes(key), sender, "", "", UChat.get().getPlayerChannel(sender)));
+            sender.sendMessage(getPrefix(sender) + " " + UCMessages.formatTags("", UChatColor.translateAlternateColorCodes(key), sender, "", "", UChat.get().getPlayerChannel(sender)));
         } else if (get(key).equalsIgnoreCase("")) {
             return;
         } else {
-            sender.sendMessage(get(sender, "_UChat.prefix") + " " + get(sender, key));
+            sender.sendMessage(getPrefix(sender) + " " + get(sender, key));
         }
 
         if (sender instanceof Player) {

--- a/UltimateChat-Sponge-56/src/main/java/br/net/fabiozumbi12/UltimateChat/Sponge/config/UCLang.java
+++ b/UltimateChat-Sponge-56/src/main/java/br/net/fabiozumbi12/UltimateChat/Sponge/config/UCLang.java
@@ -150,17 +150,25 @@ public class UCLang {
         return UCUtil.toText(get(key));
     }
 
+    private String getPrefix(final CommandSource sender) {
+        String prefix = get(sender, "_UChat.prefix");
+        if (UCUtil.stripColor('&', prefix).isEmpty()) {
+            return prefix;
+        }
+        return prefix + " ";
+    }
+
     public void sendMessage(final CommandSource p, String key) {
         if (DelayedMessage.containsKey(p) && DelayedMessage.get(p).equals(key)) {
             return;
         }
 
         if (loadedLang.get(key) == null) {
-            p.sendMessage(UCUtil.toText(get(p, "_UChat.prefix") + " " + UCMessages.formatTags("", key, p, "", "", UChat.get().getPlayerChannel(p))));
+            p.sendMessage(UCUtil.toText(getPrefix(p) + " " + UCMessages.formatTags("", key, p, "", "", UChat.get().getPlayerChannel(p))));
         } else if (get(key).equalsIgnoreCase("")) {
             return;
         } else {
-            p.sendMessage(UCUtil.toText(get(p, "_UChat.prefix") + " " + get(p, key)));
+            p.sendMessage(UCUtil.toText(getPrefix(p) + " " + get(p, key)));
         }
 
         DelayedMessage.put(p, key);


### PR DESCRIPTION
Whenever the `_UChat.prefix` locale key is set to an empty string, chat messages are still prefixed with an extra space.
This pull request fixes that by explicitly checking the prefix, and only adding a space if it's not empty.

Tested on Paper 1.15.2.
I was unable to test it on Sponge, as their maven repo is currently down.